### PR TITLE
Made variables in IO.py:print_readable_format clearer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,4 @@ The following user stories are completed according to acceptance criteria:
 
 The completion of user stories is verified through unit testing across non-IO layers of the program.
 In addition, the program is continuosly integrated, with test coverage and passing kept high throughout development.
+

--- a/src/services/IO.py
+++ b/src/services/IO.py
@@ -5,14 +5,14 @@ class KonsoliIO():
     def write_screen(self, text):
         print(text)
 
-    def print_readable_form(self, text):
-        if not text:
+    def print_readable_form(self, references):
+        if not references:
             print("\nYou do not have any references to print!\n")
 
-        for i in text:
-            doc_type = i.docutype
-            citekey = i.citekey
+        for ref in references:
+            doc_type = ref.docutype
+            citekey = ref.citekey
 
             print(f"\nType: {doc_type}, Citekey: {citekey}\n")
-            for key, value in i.bibDict.items():
+            for key, value in ref.bibDict.items():
                 print(f"{key:10} {value}")


### PR DESCRIPTION
This is for assignment 6 of this weeks set. "text" changed to "references" and "i" changed to "ref"