### PR TITLE
Week 6 exercise 6: fix naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ The following user stories are completed according to acceptance criteria:
 The completion of user stories is verified through unit testing across non-IO layers of the program.
 In addition, the program is continuosly integrated, with test coverage and passing kept high throughout development.
 
+

--- a/src/UI/ui.py
+++ b/src/UI/ui.py
@@ -1,10 +1,10 @@
 from rich.console import Console
 from services.bibtex import Bibtex
 from services.app_logic import AppLogic
-from services.file_service import File_Saver
-from services.doi_service import Doi_Service
-from repositories.bibtex_repository import BibTex_Repository
-from database_connection import get_data_base_connection
+from services.file_service import FileService
+from services.doi_service import DoiService
+from repositories.bibtex_repository import BibTexRepository
+from database_connection import get_database_connection
 
 
 class UI():
@@ -12,11 +12,11 @@ class UI():
         self.io = io
         self.bib_repo = bib_repo
         if not bib_repo:
-            self.bib_repo = BibTex_Repository(get_data_base_connection())
+            self.bib_repo = BibTexRepository(get_database_connection())
         self.app = AppLogic(self.bib_repo)
-        self.file_saver = File_Saver(self.bib_repo)
+        self.file_saver = FileService(self.bib_repo)
         self.invalid_message = "[bold red]\nInvalid input, please try again.[/bold red]"
-        self.doi_service = Doi_Service()
+        self.doi_service = DoiService()
         self.console = Console()
 
     def start(self):

--- a/src/database_connection.py
+++ b/src/database_connection.py
@@ -5,5 +5,5 @@ connection = sqlite3.connect(DATABASE_FILE_PATH)
 connection.row_factory = sqlite3.Row
 
 
-def get_data_base_connection():
+def get_database_connection():
     return connection

--- a/src/initialize_database.py
+++ b/src/initialize_database.py
@@ -1,9 +1,9 @@
-from database_connection import get_data_base_connection
+from database_connection import get_database_connection
 from config import BIBTEX_FILE_PATH
 
 
 def initialize_database():
-    connection = get_data_base_connection()
+    connection = get_database_connection()
     drop_tables(connection)
     createtable(connection)
     with open(BIBTEX_FILE_PATH, 'w', encoding='utf-8'):

--- a/src/repositories/bibtex_repository.py
+++ b/src/repositories/bibtex_repository.py
@@ -1,7 +1,7 @@
 import pickle
 
 
-class BibTex_Repository():
+class BibTexRepository():
     def __init__(self, connection):
         self._connection = connection
 

--- a/src/services/doi_service.py
+++ b/src/services/doi_service.py
@@ -2,7 +2,7 @@ import requests
 import bibtexparser
 
 
-class Doi_Service:
+class DoiService:
     def __init__(self):
         self.doi_url = 'https://dx.doi.org/'
         self.headers = {"accept": "application/x-bibtex"}

--- a/src/services/file_service.py
+++ b/src/services/file_service.py
@@ -2,7 +2,7 @@
 from config import BIBTEX_FILE_PATH
 
 
-class File_Saver:
+class FileService:
     def __init__(self, bib_repo=None):
         self.bib_repo = bib_repo
 

--- a/src/tests/doi_service_test.py
+++ b/src/tests/doi_service_test.py
@@ -1,13 +1,13 @@
 import unittest
 from unittest.mock import patch, Mock
 import requests
-from services.doi_service import Doi_Service
+from services.doi_service import DoiService
 
 
 class TestDoiService(unittest.TestCase):
 
     def setUp(self):
-        self.doi_service = Doi_Service()
+        self.doi_service = DoiService()
 
     def test_fetch_with_correct_doi(self):
         doi = '10.1016/S1574-0137(19)30321-1'

--- a/src/tests/file_service_test.py
+++ b/src/tests/file_service_test.py
@@ -1,13 +1,13 @@
 import unittest
 from unittest.mock import Mock, patch
 # replace with the actual module name
-from services.file_service import File_Saver
+from services.file_service import FileService
 
 
-class TestFileSaver(unittest.TestCase):
+class TestFileService(unittest.TestCase):
     def setUp(self):
         self.mock_bib_repo = Mock()
-        self.file_saver = File_Saver(bib_repo=self.mock_bib_repo)
+        self.file_saver = FileService(bib_repo=self.mock_bib_repo)
 
     @patch('builtins.open', new_callable=unittest.mock.mock_open)
     def test_write(self, mock_open):


### PR DESCRIPTION
This will:
- fix some class naming to CapWords (https://peps.python.org/pep-0008/#class-names)
- fix typo get_data_base_connection -> get_database_connection
- change File_Saver -> FileService for consistency